### PR TITLE
Autobind fix

### DIFF
--- a/elements/AAC-850m6/update.js
+++ b/elements/AAC-850m6/update.js
@@ -559,8 +559,10 @@ var update = function(instance, properties, context) {
     //loads initial content if initial content property is set - handles height change if expected behavior is for element to extend if there is overflow
     if (!instance.data.initial_content_loaded) {
       quill = instance.data.quill;
+      var pastedIntoHTML = false
       if (properties.initial_content) {
-        if (instance.data.current_bbcode !== properties.initial_content) {
+        // paste the HTML even if current_bbcode matches initial content, 
+        // to mitigate wrong initial content from persisting in editor if the data the RTE is autobinding to changes
           var initial_html = bbCodeToHTML(properties.initial_content);
           var current_selection = quill.getSelection()
           var scrollTop = window.scrollY
@@ -573,15 +575,18 @@ var update = function(instance, properties, context) {
           quill.setSelection(current_selection)
           // prevent paste-induced focus from autoscrolling to this position
           window.scrollTo(scrollLeft, scrollTop)
-        }
+          pastedIntoHTML = true;
+
         if(properties.overflow && !properties.initial_content.includes('[/img]')){
           instance.setHeight(calculateHeight(quill,instance.data.initial_height, instance.data.toolbar_height));
         }
+
         $(quill.root).find('img').load(() => {
           if (properties.overflow){
             instance.setHeight(calculateHeight(quill,instance.data.initial_height, instance.data.toolbar_height));
           }
         });
+
       } else {
         $(quill.root).html("");
       }
@@ -600,10 +605,10 @@ var update = function(instance, properties, context) {
       
     //positions the image resize module correctly when scrolling
     $(quill.root).on('scroll', () => {
-       var resize_obj = $(`#${instance.data.id}`).children()[3];
-       if (resize_obj && !resize_obj.hidden){
-      	  quill.theme.modules.imageResize.repositionElements();
-       }
+      var resize_obj = $(`#${instance.data.id}`).children()[3];
+      if (resize_obj && !resize_obj.hidden){
+        quill.theme.modules.imageResize.repositionElements();
+      }
     });
       
     quill = instance.data.quill;

--- a/elements/AAC-850m6/update.js
+++ b/elements/AAC-850m6/update.js
@@ -559,7 +559,6 @@ var update = function(instance, properties, context) {
     //loads initial content if initial content property is set - handles height change if expected behavior is for element to extend if there is overflow
     if (!instance.data.initial_content_loaded) {
       quill = instance.data.quill;
-      var pastedIntoHTML = false
       if (properties.initial_content) {
         // paste the HTML even if current_bbcode matches initial content, 
         // to mitigate wrong initial content from persisting in editor if the data the RTE is autobinding to changes
@@ -575,7 +574,6 @@ var update = function(instance, properties, context) {
           quill.setSelection(current_selection)
           // prevent paste-induced focus from autoscrolling to this position
           window.scrollTo(scrollLeft, scrollTop)
-          pastedIntoHTML = true;
 
         if(properties.overflow && !properties.initial_content.includes('[/img]')){
           instance.setHeight(calculateHeight(quill,instance.data.initial_height, instance.data.toolbar_height));
@@ -603,6 +601,8 @@ var update = function(instance, properties, context) {
       $(`#${instance.data.id}`).children().eq(3).hide();
     });
       
+    quill = instance.data.quill;
+      
     //positions the image resize module correctly when scrolling
     $(quill.root).on('scroll', () => {
       var resize_obj = $(`#${instance.data.id}`).children()[3];
@@ -611,8 +611,6 @@ var update = function(instance, properties, context) {
       }
     });
       
-    quill = instance.data.quill;
-
     //handles text changes and blur events
     var set_val = () => {
       $.when(htmlToBBCode(quill.root.innerHTML)).done((html_to_bbcode) => {


### PR DESCRIPTION
https://internal.bubbleapps.io/task/rte-autobind-does-not-kick-in-when-workflow-is-run-to-change-data-source-of-1593030578091x559872607698026500